### PR TITLE
Support server-side rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ import { useTransactionObservation_UNSTABLE } from 'recoil'
  *    `localStorage`. Defaults value is `localStorage`.
  */
 export function recoilPersist(paths = [], config = {}) {
+  if (typeof window === 'undefined') {
+    return { RecoilPersist: () => null, updateState: () => {} }
+  }
+  
   const key = config.key || 'recoil-persist'
   const storage = config.storage || localStorage
 


### PR DESCRIPTION
Fixes: https://github.com/polemius/recoil-persist/issues/6

Currently recoil-persist would break in environments where `window` object is not available, e.g. Next.JS server-side rendering.
This PR fixes it.