### PR TITLE
Declare package as type:module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.0",
   "description": "Package for recoil to persist and rehydrate store",
   "main": "index.js",
+  "type": "module",
   "repository": "polemius/recoil-persist",
   "author": "Ivan Menshykov <ivan.menshykov@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
I cannot import this package from Next.JS because it's using ES6 module but doesn't declare itself as a module. I get `Uncaught SyntaxError: Cannot use import statement outside a module`

An alternative could have been to publish transpiled code in order to support IE11, but that's obviously much harder.