### PR TITLE
Add testing for async use case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 import { AtomEffect } from 'recoil'
 
-interface Storage {
-  setItem(key: string, value: string): void | Promise<any>
-  getItem(key: string): null | string | Promise<any>
+export interface PersistStorage {
+  setItem(key: string, value: string): void | Promise<void>
+
+  getItem(key: string): null | string | Promise<string>
 }
 
 export interface PersistConfiguration {
   key?: string
-  storage?: Storage
+  storage?: PersistStorage
 }
 
 /**
@@ -24,7 +25,8 @@ export const recoilPersist = (
 
   if (typeof window === 'undefined') {
     return {
-      persistAtom: () => {},
+      persistAtom: () => {
+      },
     }
   }
 
@@ -76,6 +78,8 @@ export const recoilPersist = (
 
   const setState = (state: any): void => {
     try {
+      //TODO for React Native `AsyncStorage`, we should be using `mergeItem`
+      // to merge existing stringified object with new one
       storage.setItem(key, JSON.stringify(state))
     } catch (e) {
       console.error(e)

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -1,73 +1,24 @@
 import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { atom, atomFamily, RecoilRoot, useRecoilState } from 'recoil'
-import { recoilPersist } from '../src'
+import { PersistStorage, recoilPersist } from '../src'
 
-const { persistAtom } = recoilPersist()
+interface TestableStorage extends PersistStorage {
+  name: string,
 
-const counterState = atom({
-  key: 'count',
-  default: 0,
-  effects_UNSTABLE: [persistAtom],
-})
+  getState(): any,
 
-const counterFamily = atomFamily({
-  key: 'countFamily',
-  default: 0,
-  effects_UNSTABLE: [persistAtom],
-})
-
-const counterState4 = atom({
-  key: 'count4',
-  default: 0,
-})
-
-function Demo() {
-  const [count, setCount] = useRecoilState(counterState)
-  const [count2, setCount2] = useRecoilState(counterFamily('2'))
-  const [count3, setCount3] = useRecoilState(counterFamily('3'))
-  const [count4, setCount4] = useRecoilState(counterState4)
-  return (
-    <div>
-      <p data-testid="count-value">{count}</p>
-      <p data-testid="count2-value">{count2}</p>
-      <p data-testid="count3-value">{count3}</p>
-      <p data-testid="count4-value">{count4}</p>
-      <button data-testid="count-increase" onClick={() => setCount(count + 1)}>
-        Increase
-      </button>
-      <button
-        data-testid="count2-increase"
-        onClick={() => setCount2(count2 + 1)}
-      >
-        Increase 2
-      </button>
-      <button
-        data-testid="count3-increase"
-        onClick={() => setCount3(count3 + 1)}
-      >
-        Increase 3
-      </button>
-      <button
-        data-testid="count4-increase"
-        onClick={() => setCount4(count4 + 1)}
-      >
-        Increase 4
-      </button>
-    </div>
-  )
+  clear(): void
 }
 
-const error = jest.fn()
-console.error = error
-
-const asyncStorage = () => {
+const asyncStorage = (): TestableStorage => {
   let s = {}
   return {
+    name: 'async',
     setItem: (key: string, value: string) => {
       return new Promise((resolve) => {
         s[key] = value
-        resolve(value)
+        resolve()
       })
     },
     getItem: (key: string): Promise<string> => {
@@ -75,189 +26,219 @@ const asyncStorage = () => {
         resolve(s[key])
       })
     },
+    getState: () => s,
     clear: () => {
       s = {}
     },
   }
 }
 
-const storage = asyncStorage()
-
-const { persistAtom: persistAtomAsync } = recoilPersist({
-  storage,
-})
-
-const counterStateAsync = atom({
-  key: 'count_async',
-  default: 0,
-  effects_UNSTABLE: [persistAtomAsync],
-})
-
-function DemoAsync() {
-  const [count, setCount] = useRecoilState(counterStateAsync)
-
-  return (
-    <div>
-      <p data-testid="count-value">{count}</p>
-      <button data-testid="count-increase" onClick={() => setCount(count + 1)}>
-        Increase
-      </button>
-    </div>
-  )
+const syncStorage = (): TestableStorage => {
+  let s = {}
+  return {
+    name: 'sync',
+    setItem: (key: string, value: string) => {
+      s[key] = value
+    },
+    getItem: (key: string): string => {
+      return s[key]
+    },
+    getState: () => s,
+    clear: () => {
+      s = {}
+    },
+  }
 }
 
-afterEach(() => {
-  localStorage.clear()
-  sessionStorage.clear()
-  jest.restoreAllMocks()
-  error.mockClear()
-  storage.clear()
-})
+testPersistWith(asyncStorage())
+testPersistWith(syncStorage())
 
-it('should update localStorage', async () => {
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
+function testPersistWith(storage: TestableStorage) {
+  describe(`Storage: ${storage.name}`, () => {
+    const testKey = 'test-key'
+    const { persistAtom } = recoilPersist({ key: testKey, storage })
 
-  fireEvent.click(getByTestId('count-increase'))
-  await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('1'))
-  expect(JSON.parse(localStorage.getItem('recoil-persist'))).toStrictEqual({
-    count: 1,
+    const getStateValue = () => {
+      return JSON.parse(storage.getState()[testKey])
+    }
+
+    const getAtomKey = (key: string) => {
+      return `${storage.name}_${key}`
+    }
+
+    const counterState = atom({
+      key: getAtomKey('count'),
+      default: 0,
+      effects_UNSTABLE: [persistAtom],
+    })
+
+    const counterFamily = atomFamily({
+      key: getAtomKey('countFamily'),
+      default: 0,
+      effects_UNSTABLE: [persistAtom],
+    })
+
+    const counterState4 = atom({
+      key: getAtomKey('count4'),
+      default: 0,
+    })
+
+    function Demo() {
+      const [count, setCount] = useRecoilState(counterState)
+      const [count2, setCount2] = useRecoilState(counterFamily('2'))
+      const [count3, setCount3] = useRecoilState(counterFamily('3'))
+      const [count4, setCount4] = useRecoilState(counterState4)
+      return (
+        <div>
+          <p data-testid='count-value'>{count}</p>
+          <p data-testid='count2-value'>{count2}</p>
+          <p data-testid='count3-value'>{count3}</p>
+          <p data-testid='count4-value'>{count4}</p>
+          <button data-testid='count-increase' onClick={() => setCount(count + 1)}>
+            Increase
+          </button>
+          <button data-testid='count2-increase' onClick={() => setCount2(count2 + 1)}>
+            Increase 2
+          </button>
+          <button data-testid='count3-increase' onClick={() => setCount3(count3 + 1)}>
+            Increase 3
+          </button>
+          <button data-testid='count4-increase' onClick={() => setCount4(count4 + 1)}>
+            Increase 4
+          </button>
+        </div>
+      )
+    }
+
+    beforeEach(() => {
+      console.error = jest.fn()
+    })
+
+    afterEach(() => {
+      storage.clear()
+      jest.restoreAllMocks()
+    })
+
+    it('should update storage', async () => {
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+
+      fireEvent.click(getByTestId('count-increase'))
+      await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('1'))
+
+      expect(getStateValue()).toStrictEqual({
+        [getAtomKey('count')]: 1,
+      })
+    })
+
+    it('should update storage if using atomFamily', async () => {
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+      fireEvent.click(getByTestId('count2-increase'))
+      fireEvent.click(getByTestId('count3-increase'))
+      await waitFor(() => expect(getByTestId('count2-value').innerHTML).toBe('1'))
+      await waitFor(() => expect(getByTestId('count3-value').innerHTML).toBe('1'))
+
+      expect(getStateValue()).toStrictEqual({
+        [getAtomKey('countFamily__"2"')]: 1,
+        [getAtomKey('countFamily__"3"')]: 1,
+      })
+    })
+
+    it('should not persist atom with no effect', async () => {
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+
+      fireEvent.click(getByTestId('count4-increase'))
+      await waitFor(() => expect(getByTestId('count4-value').innerHTML).toBe('1'))
+
+      expect(storage.getState()[testKey]).toBeUndefined()
+    })
+
+    it('should read state from storage', async () => {
+      await storage.setItem(
+        testKey,
+        JSON.stringify({ [getAtomKey('count')]: 1, [getAtomKey('countFamily__"2"')]: 1 }),
+      )
+
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+
+      expect(getByTestId('count-value').innerHTML).toBe('1')
+      expect(getByTestId('count2-value').innerHTML).toBe('1')
+    })
+
+    it('should use default value if not in storage', async () => {
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+
+      expect(getByTestId('count3-value').innerHTML).toBe('0')
+    })
+
+    it('should handle non jsonable object in storage', async () => {
+      storage.setItem(testKey, 'test string')
+
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+
+      fireEvent.click(getByTestId('count-increase'))
+      await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('1'))
+
+      expect(getStateValue()).toStrictEqual({
+        [getAtomKey('count')]: 1,
+      })
+    })
+
+    it('should handle non jsonable object in state', async () => {
+      let mock = jest.spyOn(JSON, 'stringify').mockImplementation(() => {
+        throw Error('mock error')
+      })
+
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+
+      fireEvent.click(getByTestId('count-increase'))
+      await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('1'))
+      expect(mock).toHaveBeenCalledTimes(1)
+      expect(console.error).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle non-existent atom name stored in storage', async () => {
+      storage.setItem(
+        testKey,
+        JSON.stringify({
+          notExist: 'test value',
+        }),
+      )
+
+      const { getByTestId } = render(
+        <RecoilRoot>
+          <Demo />
+        </RecoilRoot>,
+      )
+
+      await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('0'))
+    })
   })
-  expect(sessionStorage.getItem('recoil-persist')).toBeNull()
-})
-
-it('should update localStorage if using atomFamily', async () => {
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
-  fireEvent.click(getByTestId('count2-increase'))
-  fireEvent.click(getByTestId('count3-increase'))
-  await waitFor(() => expect(getByTestId('count2-value').innerHTML).toBe('1'))
-  await waitFor(() => expect(getByTestId('count3-value').innerHTML).toBe('1'))
-  expect(JSON.parse(localStorage.getItem('recoil-persist'))).toStrictEqual({
-    'countFamily__"2"': 1,
-    'countFamily__"3"': 1,
-  })
-})
-
-it('should not persist atom with no effect', async () => {
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
-
-  fireEvent.click(getByTestId('count4-increase'))
-  await waitFor(() => expect(getByTestId('count4-value').innerHTML).toBe('1'))
-  expect(JSON.parse(localStorage.getItem('recoil-persist'))).toBeNull()
-})
-
-it('should read state from localStorage', async () => {
-  localStorage.setItem(
-    'recoil-persist',
-    JSON.stringify({ count: 1, 'countFamily__"2"': 1 }),
-  )
-
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
-
-  expect(getByTestId('count-value').innerHTML).toBe('1')
-  expect(getByTestId('count2-value').innerHTML).toBe('1')
-})
-
-it('should use default value if not in storage', async () => {
-  localStorage.setItem(
-    'recoil-persist',
-    JSON.stringify({ count: 1, 'countFamily__"2"': 1 }),
-  )
-
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
-
-  expect(getByTestId('count3-value').innerHTML).toBe('0')
-})
-
-it('should handle non :jsonable object in localStorage', async () => {
-  localStorage.setItem('recoil-persist', 'test string')
-
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
-
-  await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('0'))
-})
-
-it('should handle non jsonable object in state', async () => {
-  let mock = jest.spyOn(JSON, 'stringify').mockImplementation(() => {
-    throw Error('mock error')
-  })
-
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
-
-  fireEvent.click(getByTestId('count-increase'))
-  await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('1'))
-  expect(mock).toHaveBeenCalledTimes(1)
-  expect(console.error).toHaveBeenCalledTimes(1)
-})
-
-it('should handle non-existent atom name stored in storage', async () => {
-  localStorage.setItem(
-    'recoil-persist',
-    JSON.stringify({
-      notExist: 'test value',
-    }),
-  )
-
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <Demo />
-    </RecoilRoot>,
-  )
-
-  await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('0'))
-})
-
-it('should handle store if it return Promise', async () => {
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <DemoAsync />
-    </RecoilRoot>,
-  )
-
-  fireEvent.click(getByTestId('count-increase'))
-  await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('1'))
-  const value = await storage.getItem('recoil-persist')
-
-  expect(JSON.parse(value)).toStrictEqual({
-    count_async: 1,
-  })
-})
-
-it('should read state from async storage', async () => {
-  await storage.setItem('recoil-persist', JSON.stringify({ count_async: 10 }))
-
-  const { getByTestId } = render(
-    <RecoilRoot>
-      <DemoAsync />
-    </RecoilRoot>,
-  )
-
-  await waitFor(() => expect(getByTestId('count-value').innerHTML).toBe('10'))
-})
+}


### PR DESCRIPTION
I've made sure that all tests run across both sync and async storage use cases, after seeing issues #19 and #20. A few tests are failing, without any change to the async implementation. I'd suggest merging this PR and creating a new issue to track the failing tests.