### PR TITLE
Remove key on reset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,13 @@ export const recoilPersist = (
 
     onSet((newValue) => {
       const state = getState()
-      state[node.key] = newValue
+     
+      if (newValue instanceof DefaultValue) {
+        if(state.hasOwnProperty(node.key)) delete state[node.key];
+      } else {
+        state[node.key] = newValue
+      }
+      
       setState(state)
     })
   }


### PR DESCRIPTION
as per the docs https://recoiljs.org/docs/guides/atom-effects/#asynchronous-storage-persistence
when reseting we should remove the key completely. It will re-hydrate next run.
As of now it just stores it as an empty object when doing a reset. 