### PR TITLE
Compatibility with localForage

### DIFF
--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -25,7 +25,7 @@ const asyncStorage = (): TestableStorage => {
     setItem: (key: string, value: string) => {
       return new Promise((resolve) => {
         s[key] = value
-        resolve()
+        resolve(undefined)
       })
     },
     getItem: (key: string): Promise<string> => {
@@ -103,7 +103,8 @@ function testPersistWith(storage: TestableStorage) {
       const updateMultiple = useRecoilCallback(({ set }) => () => {
         set(counterState, 10)
         set(counterFamily('2'), 10)
-      })
+      }, []);
+
       return (
         <div>
           <p data-testid="count-value">{count}</p>
@@ -382,7 +383,7 @@ function testPersistWith(storage: TestableStorage) {
       )
     })
 
-    it.skip('should handle updating multiple atomes', async () => {
+    it('should handle updating multiple atoms', async () => {
       const { getByTestId } = render(
         <RecoilRoot>
           <Demo />


### PR DESCRIPTION
`localForage` is incompatible with `recoil-storage`, return types are different.

`localForage.getItem()` returns `Promise<null|string>`. which makes getState return null, as there is no check for `null` from a promise.

`localForage.setItem()` returns `Promise<string>`. but `recoil-storage` doesn't care about that anyway, so doesn't have to enforce those types.

Making getState return a Promise always simplifies the code a lot, though that commit doesn't need to be part of this, but it better enforces the types.