### PR TITLE
Fix: Async getItem function may return null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { AtomEffect } from 'recoil'
 export interface PersistStorage {
   setItem(key: string, value: string): void | Promise<void>
   mergeItem?(key: string, value: string): Promise<void>
-  getItem(key: string): null | string | Promise<string>
+  getItem(key: string): null | string | Promise<string | null>
 }
 
 export interface PersistConfiguration {
@@ -78,7 +78,7 @@ export const recoilPersist = (
       return parseState(toParse)
     }
     if (typeof toParse.then === 'function') {
-      return toParse.then(parseState)
+      return toParse.then(state => state === null ? '{}' : state).then(parseState)
     }
 
     return {}


### PR DESCRIPTION
getItem function in AsyncStorage may return null.
For this reason I have changed getItem to accept `Promise<string | null>` and added handling if null is returned.