### PR TITLE
Feat/synchronize windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export interface StorageEvent {
 export interface PersistConfiguration {
   key?: string
   storage?: PersistStorage
-  addStorageListener?: (listener: (e: StorageEvent) => void) => ReturnType<AtomEffect<any>>
+  addStorageListener?: ((listener: (e: StorageEvent) => void) => ReturnType<AtomEffect<any>>) | null
 }
 
 /**


### PR DESCRIPTION
This PR uses the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) so that when the localStorage is modified outside of the application it is synchronized back to recoil.

This allows for synchronization of state between multiple tabs/windows/iframe, and updates the application's recoil state when a developer edits the localState within "Application" tab of chrome DevTools.

With the `addStorageListener` property of `PersistConfiguration`, the functionality can be adapted to storage configurations other than the `localStorage`, or if this is undesired, it can be disabled.