### PR TITLE
Fix PersistStorage.getItem async typing to match sync version.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { AtomEffect } from 'recoil'
 export interface PersistStorage {
   setItem(key: string, value: string): void | Promise<void>
   mergeItem?(key: string, value: string): Promise<void>
-  getItem(key: string): null | string | Promise<string>
+  getItem(key: string): null | string | Promise<null | string>
 }
 
 export interface PersistConfiguration {


### PR DESCRIPTION
Async typing does not include `null`